### PR TITLE
Fix the faucet port to be the same as the port used by docker-compose

### DIFF
--- a/localnet/single/README.md
+++ b/localnet/single/README.md
@@ -30,7 +30,7 @@
 
 ### Checking the faucets status
 ```shell
-curl http://localhost:8000/status
+curl http://localhost:8081/status
 ```
 
 ### Using the faucet
@@ -38,7 +38,7 @@ curl http://localhost:8000/status
 curl --header "Content-Type: application/json" \
 --request POST \
 --data '{"denom":"cony", "address":"link1pheah96n54rwnuu4xej9egwwggn3h8uvv7pjdu"}' \
-http://localhost:8000/credit
+http://localhost:8081/credit
 ```
 
 

--- a/localnet/single/faucet.sh
+++ b/localnet/single/faucet.sh
@@ -18,7 +18,7 @@ docker run --read-only --rm -d \
 -e FAUCET_CONCURRENCY \
 -e FAUCET_PATH_PATTERN \
 -e FAUCET_MNEMONIC \
--p 8000:8000 \
+-p 8081:8000 \
 --platform=linux/amd64 \
 confio/faucet:0.29.0 \
 start "$DOCKER_HOST_IP:26657"


### PR DESCRIPTION
This PR changes the faucet port to be the same as the port used by docker-compose.